### PR TITLE
Association Extensions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem "bootsnap", require: false
 gem "sassc-rails"
 gem 'webpacker'
 gem 'bcrypt'
+gem 'will_paginate'
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,9 +94,6 @@ GEM
       activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    image_processing (1.12.2)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (1.1.5)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -117,7 +114,6 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
-    mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.7.0)
@@ -173,8 +169,6 @@ GEM
     reline (0.3.3)
       io-console (~> 0.5)
     rexml (3.2.5)
-    ruby-vips (2.1.4)
-      ffi (~> 1.12)
     rubyzip (2.3.2)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -228,6 +222,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    will_paginate (3.3.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.7)
@@ -240,7 +235,6 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
-  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   puma (~> 5.0)
@@ -255,6 +249,7 @@ DEPENDENCIES
   web-console
   webdrivers
   webpacker
+  will_paginate
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,19 +1,14 @@
-#---
-# Excerpted from "Agile Web Development with Rails 6",
-# published by The Pragmatic Bookshelf.
-# Copyrights apply to this code. It may not be used to create training material,
-# courses, books, articles, and the like. Contact us if you are in doubt.
-# We make no guarantees that this code is fit for any purpose.
-# Visit http://www.pragmaticprogrammer.com/titles/rails6 for more book information.
-#---
 class ApplicationController < ActionController::Base
   before_action :set_i18n_locale_from_params
-  # ...
   before_action :authorize
 
-    # ...
+  helper_method :current_user
 
   protected
+
+    def current_user
+      @current_user ||= User.find_by_id(session[:user_id])
+    end
 
     def authorize
       if request.format == Mime[:html]
@@ -33,8 +28,7 @@ class ApplicationController < ActionController::Base
         if I18n.available_locales.map(&:to_s).include?(params[:locale])
           I18n.locale = params[:locale]
         else
-          flash.now[:notice] = 
-            "#{params[:locale]} translation not available"
+          flash.now[:notice] = "#{params[:locale]} translation not available"
           logger.error flash.now[:notice]
         end
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,5 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
-  before_action :set_current_user, only: [:orders, :line_items]
   # GET /users
   # GET /users.json
   def index
@@ -71,11 +70,11 @@ class UsersController < ApplicationController
   end
 
   def orders
-    @orders = @user.orders.paginate(page: params[:page], per_page: 5)
+    @orders = current_user.orders.paginate(page: params[:page], per_page: 5)
   end
 
   def line_items
-    @line_items = @user.line_items.paginate(page: params[:page], per_page: 5)
+    @line_items = current_user.line_items.paginate(page: params[:page], per_page: 5)
   end
 
   private
@@ -85,11 +84,8 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
-  def set_current_user
-    @user = User.find(session[:user_id])
-  end
   # Only allow a list of trusted parameters through.
   def user_params
-    params.require(:user).permit(:name, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,14 +1,6 @@
-#---
-# Excerpted from "Agile Web Development with Rails 6",
-# published by The Pragmatic Bookshelf.
-# Copyrights apply to this code. It may not be used to create training material,
-# courses, books, articles, and the like. Contact us if you are in doubt.
-# We make no guarantees that this code is fit for any purpose.
-# Visit http://www.pragmaticprogrammer.com/titles/rails6 for more book information.
-#---
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
-
+  before_action :set_current_user, only: [:orders, :line_items]
   # GET /users
   # GET /users.json
   def index
@@ -78,14 +70,26 @@ class UsersController < ApplicationController
     redirect_to users_url, notice: exception.message
   end
 
-  private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_user
-      @user = User.find(params[:id])
-    end
+  def orders
+    @orders = @user.orders.paginate(page: params[:page], per_page: 5)
+  end
 
-    # Only allow a list of trusted parameters through.
-    def user_params
-      params.require(:user).permit(:name, :password, :password_confirmation)
-    end
+  def line_items
+    @line_items = @user.line_items.paginate(page: params[:page], per_page: 5)
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def set_current_user
+    @user = User.find(session[:user_id])
+  end
+  # Only allow a list of trusted parameters through.
+  def user_params
+    params.require(:user).permit(:name, :password, :password_confirmation)
+  end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,7 +1,6 @@
 class Cart < ApplicationRecord
   has_many :line_items, dependent: :destroy
   has_many :products, through: :line_items
-  has_many :enabled_products, -> { where enabled: true }, through: :line_items
 
   def add_product(product)
     current_item = line_items.find_by(product_id: product.id)

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -1,5 +1,7 @@
 class Cart < ApplicationRecord
   has_many :line_items, dependent: :destroy
+  has_many :products, through: :line_items
+  has_many :enabled_products, -> { where enabled: true }, through: :line_items
 
   def add_product(product)
     current_item = line_items.find_by(product_id: product.id)

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -1,9 +1,9 @@
 class LineItem < ApplicationRecord
   belongs_to :order, optional: true
   belongs_to :product, optional: true
-  belongs_to :cart, optional: true
+  belongs_to :cart, optional: true, counter_cache: true
 
-  validates :product_id, uniqueness: { scope: :cart_id, message: 'cart cannot have multiple same product' }
+  validates :product_id, uniqueness: { scope: :cart_id, message: 'cart cannot have multiple same product' }, if: :cart_id?
 
   def total_price
     product.price * quantity

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,7 +12,7 @@ class Order < ApplicationRecord
   validates :name, :address, :email, presence: true
   validates :pay_type, inclusion: pay_types.keys
 
-  scope :by_date, -> (from = Time.now.midnight, to = Time.now) { where(created_at: from..to) }
+  scope :by_date, -> (from = Time.current.beginning_of_day, to = Time.current.end_of_day) { where(created_at: (from..to)) }
 
   def add_line_items_from_cart(cart)
     cart.line_items.each do |item|
@@ -55,8 +55,6 @@ class Order < ApplicationRecord
   end
 
   def total_price
-    line_items.inject 0 do |total_price, line_item|
-      total_price += line_item.total_price
-    end
+    line_items.sum(&:total_price)
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,16 +1,17 @@
-
 require 'pago'
 
 class Order < ApplicationRecord
   enum pay_type: {
-    "Check"          => 0, 
-    "Credit card"    => 1, 
+    "Check"          => 0,
+    "Credit card"    => 1,
     "Purchase order" => 2
   }
   has_many :line_items, dependent: :destroy
+  belongs_to :user
   # ...
   validates :name, :address, :email, presence: true
   validates :pay_type, inclusion: pay_types.keys
+
   def add_line_items_from_cart(cart)
     cart.line_items.each do |item|
       item.cart_id = nil
@@ -48,6 +49,12 @@ class Order < ApplicationRecord
       OrderMailer.received(self).deliver_later
     else
       raise payment_result.error
+    end
+  end
+
+  def total_price
+    line_items.inject 0 do |total_price, line_item|
+      total_price += line_item.total_price
     end
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,6 +12,8 @@ class Order < ApplicationRecord
   validates :name, :address, :email, presence: true
   validates :pay_type, inclusion: pay_types.keys
 
+  scope :by_date, -> (from = Time.now.midnight, to = Time.now) { where(created_at: from..to) }
+
   def add_line_items_from_cart(cart)
     cart.line_items.each do |item|
       item.cart_id = nil

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -15,9 +15,9 @@ class Product < ApplicationRecord
   after_initialize :set_title, unless: :title?
   before_validation :set_discount_price, unless: :discount_price?
 
-  scope :enabled_products, -> { where enabled: true }
-  scope :product_ordered, -> { joins(:line_items).distinct }
-  scope :product_title_ordered, -> { product_ordered.pluck :title }
+  scope :enabled, -> { where(enabled: true) }
+  scope :ordered_atleast_once, -> { joins(:line_items).distinct }
+  scope :title_ordered_atleast_once, -> { ordered_atleast_once.pluck(:title) }
 
   private
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -15,6 +15,10 @@ class Product < ApplicationRecord
   after_initialize :set_title, unless: :title?
   before_validation :set_discount_price, unless: :discount_price?
 
+  scope :enabled_products, -> { where enabled: true }
+  scope :product_ordered, -> { joins(:line_items).distinct }
+  scope :product_title_ordered, -> { product_ordered.pluck :title }
+
   private
 
   def set_discount_price

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -17,7 +17,7 @@ class Product < ApplicationRecord
 
   scope :enabled, -> { where(enabled: true) }
   scope :ordered_atleast_once, -> { joins(:line_items).distinct }
-  scope :title_ordered_atleast_once, -> { ordered_atleast_once.pluck(:title) }
+  scope :title_for_ordered_atleast_once, -> { ordered_atleast_once.pluck(:title) }
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :orders
+  has_many :line_items, through: :orders
 
   validates :name, presence: true, uniqueness: true
   has_secure_password

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_many :orders
+  has_many :orders, dependent: :restrict_with_error
   has_many :line_items, through: :orders
 
   validates :name, presence: true, uniqueness: true

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -22,8 +22,8 @@
   </div>
 
   <div class="field">
-    <%= form.label :email %>
-    <%= form.text_field :email %>
+    <%= form.label :email, 'Email:' %>
+    <%= form.text_field :email, size: 40 %>
   </div>
 
   <div class="field">
@@ -37,7 +37,7 @@
     <%= form.password_field :password_confirmation,
                             id: :user_password_confirmation,
                             size: 40 %>
-    
+
   </div>
 
   <div class="actions">

--- a/app/views/users/line_items.html.erb
+++ b/app/views/users/line_items.html.erb
@@ -1,0 +1,14 @@
+<% @line_items.each do |line_item|%>
+  <%total_line_items = line_item.id%>
+  <h1><%="LINE ITEM: #{total_line_items}"%>
+  <h3>Line Item ID<h3>
+  <%= line_item.id%>
+  <h3>Product Id<h3>
+  <%= line_item.product_id%>
+  <h3>Quantity<h3>
+  <%= line_item.quantity%>
+  <h3>Order ID<h3>
+  <%= line_item.order_id%>
+  <br>
+<%end%>
+<%= will_paginate @line_items %>

--- a/app/views/users/line_items.html.erb
+++ b/app/views/users/line_items.html.erb
@@ -1,14 +1,27 @@
-<% @line_items.each do |line_item|%>
-  <%total_line_items = line_item.id%>
-  <h1><%="LINE ITEM: #{total_line_items}"%>
-  <h3>Line Item ID<h3>
-  <%= line_item.id%>
-  <h3>Product Id<h3>
-  <%= line_item.product_id%>
-  <h3>Quantity<h3>
-  <%= line_item.quantity%>
-  <h3>Order ID<h3>
-  <%= line_item.order_id%>
-  <br>
+<% if @line_items.empty? %>
+  <h3> No Line Items Present </h3>
+<% else %>
+  <style>
+    table, th, td {
+      border:1px solid black;
+    }
+  </style>
+  <h1> Line Item Details </h1>
+  <table style="width:100%">
+    <tr>
+      <th>Id</th>
+      <th>Product Id</th>
+      <th>Quantity</th>
+      <th>Order Id</th>
+    </tr>
+    <% @line_items.each do |line_item|%>
+      <tr>
+        <td><%= line_item.id%></td>
+        <td><%= line_item.product_id%></td>
+        <td><%= line_item.quantity%></td>
+        <td><%= line_item.order_id%></td>
+      </tr>
+    <%end%>
+  </table>
 <%end%>
 <%= will_paginate @line_items %>

--- a/app/views/users/orders.html.erb
+++ b/app/views/users/orders.html.erb
@@ -1,0 +1,19 @@
+<% total = 0%>
+<% @orders.each do |order|%>
+  <%order_count = order.id%>
+  <h1><%="ORDER #{order_count}"%></h1>
+  <h3>Id</h3>
+  <%= order.id%>
+  <h3>Name</h3>
+  <%= order.name%>
+  <h3>Address</h3>
+  <%= order.address%>
+  <h3>Email</h3>
+  <%= order.email%>
+  <h3>Pay Type</h3>
+  <%= order.pay_type%>
+  <h3>Total Price</h3>
+  <%="total price is: #{order.total_price}"%>
+  <br><br><br>
+<%end%>
+<%= will_paginate @orders %>

--- a/app/views/users/orders.html.erb
+++ b/app/views/users/orders.html.erb
@@ -1,19 +1,31 @@
-<% total = 0%>
-<% @orders.each do |order|%>
-  <%order_count = order.id%>
-  <h1><%="ORDER #{order_count}"%></h1>
-  <h3>Id</h3>
-  <%= order.id%>
-  <h3>Name</h3>
-  <%= order.name%>
-  <h3>Address</h3>
-  <%= order.address%>
-  <h3>Email</h3>
-  <%= order.email%>
-  <h3>Pay Type</h3>
-  <%= order.pay_type%>
-  <h3>Total Price</h3>
-  <%="total price is: #{order.total_price}"%>
-  <br><br><br>
+<% if @orders.empty? %>
+  <h3> No Order placed </h3>
+<% else %>
+  <style>
+    table, th, td {
+      border:1px solid black;
+    }
+  </style>
+  <h1> Order Details </h1>
+  <table style="width:100%">
+    <tr>
+      <th>Id</th>
+      <th>Name</th>
+      <th>Address</th>
+      <th>Email</th>
+      <th>Pay Type</th>
+      <th>Total Price</th>
+    </tr>
+    <% @orders.each do |order|%>
+      <tr>
+        <td><%= order.id%></td>
+        <td><%= order.name%></td>
+        <td><%= order.address%></td>
+        <td><%= order.email%></td>
+        <td><%= order.pay_type%></td>
+        <td><%= order.total_price%></td>
+      </tr>
+    <%end%>
+  </table>
 <%end%>
 <%= will_paginate @orders %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,3 @@
-#---
-# Excerpted from "Agile Web Development with Rails 6",
-# published by The Pragmatic Bookshelf.
-# Copyrights apply to this code. It may not be used to create training material,
-# courses, books, articles, and the like. Contact us if you are in doubt.
-# We make no guarantees that this code is fit for any purpose.
-# Visit http://www.pragmaticprogrammer.com/titles/rails6 for more book information.
-#---
 Rails.application.routes.draw do
   get 'admin' => 'admin#index'
   controller :sessions do
@@ -14,12 +6,20 @@ Rails.application.routes.draw do
     delete 'logout' => :destroy
   end
 
-  get 'users/orders', to: 'users#orders'
-  get 'users/line_items', to: 'users#line_items'
   get 'sessions/create'
   get 'sessions/destroy'
 
-  resources :users
+  resources :users do
+    # revisit once during routing
+    # resources :users do
+    #   get 'orders', to: 'users#orders'
+    # end
+    collection do
+      get 'orders', to: 'users#orders'
+      get 'line_items', to: 'users#line_items'
+    end
+  end
+
   resources :products do
     get :who_bought, on: :member
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
     post 'login' => :create
     delete 'logout' => :destroy
   end
+
+  get 'users/orders', to: 'users#orders'
+  get 'users/line_items', to: 'users#line_items'
   get 'sessions/create'
   get 'sessions/destroy'
 

--- a/db/migrate/20230427084419_add_user_id_to_orders.rb
+++ b/db/migrate/20230427084419_add_user_id_to_orders.rb
@@ -1,0 +1,5 @@
+class AddUserIdToOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :orders, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_17_065606) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_27_084419) do
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
     t.integer "status", default: 0, null: false
     t.string "message_id", null: false
@@ -84,6 +84,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_17_065606) do
     t.integer "pay_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "products", force: :cascade do |t|
@@ -121,5 +123,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_17_065606) do
   add_foreign_key "line_items", "carts"
   add_foreign_key "line_items", "orders"
   add_foreign_key "line_items", "products"
+  add_foreign_key "orders", "users"
   add_foreign_key "support_requests", "orders"
 end


### PR DESCRIPTION
We have before_destroy :ensure_not_referenced_by_line_item in Product. Now lets try a better implementation of this  using association options. So a product should not be destroyed if there is any line_item(s) associated with the product.
 Create an association on cart through which we could get all the products associated with the cart.
 Create an association on product through which we could get all the carts associated with the product.
 Create an association on cart model through which I could get all enabled products associated with it.
 Everytime a line_item is added or removed from cart, line_items_count column in cart table should be automatically incremented or decremented	.
Add an association between user and order. Then add another page in the application which can be accessed by localhost:3000/users/orders and display logged in user’s all orders with total amount and line_items. 
Then add another page localhost:3000/users/line_Items which should display all line_items that current users has ordered till date. All lineitems for the user should come from association. like user.line_items
This list should be paginated. 5 items per page

