### PR TITLE
Query interface Extensions

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,6 +12,8 @@ class Order < ApplicationRecord
   validates :name, :address, :email, presence: true
   validates :pay_type, inclusion: pay_types.keys
 
+  scope :by_date, -> (from = Time.now.midnight, to = Time.now) { where(created_at: from..to) }
+
   def add_line_items_from_cart(cart)
     cart.line_items.each do |item|
       item.cart_id = nil

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -15,6 +15,10 @@ class Product < ApplicationRecord
   after_initialize :set_title, unless: :title?
   before_validation :set_discount_price, unless: :discount_price?
 
+  scope :enabled_products, -> { where enabled: true }
+  scope :product_ordered, -> { joins(:line_items).distinct }
+  scope :product_title_ordered, -> { product_ordered.pluck :title }
+
   private
 
   def set_discount_price


### PR DESCRIPTION
Make a scope for all the enabled products
Add another scope in order which accept two dates and return orders placed between those dates
Order.by_date(from, to)
Order.by_date : without arguments, should return order for the current day
user.orders.by_date should work and it should return orders placed by user between given dates. Check the query difference in this one and the above one
    Build queries for following
     		- Get All products which are present in atleast one line_item
     		- Get array of product titles which are present in atleast one line item
