### PR TITLE
Category Exercise Extensions

### DIFF
--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -1,5 +1,4 @@
 class CategoryController < ApplicationController
   def index
-    @categories = Category.includes(:sub_categories).where(parent_category_id: nil)
-  end
+    @categories = Category.root.includes(:sub_categories)
 end

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -1,0 +1,5 @@
+class CategoryController < ApplicationController
+  def index
+    @categories = Category.includes(:sub_categories).where(parent_category_id: nil)
+  end
+end

--- a/app/helpers/category_helper.rb
+++ b/app/helpers/category_helper.rb
@@ -1,0 +1,2 @@
+module CategoryHelper
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,41 +1,30 @@
 class Category < ApplicationRecord
-  has_many :sub_categories, class_name: 'Category', foreign_key: 'parent_category_id', dependent: :destroy
-  belongs_to :parent_category, class_name: 'Category', optional: :true
+  has_many :sub_categories, class_name: 'Category', foreign_key: 'parent_id', dependent: :destroy
+  belongs_to :parent, class_name: 'Category', optional: :true
   has_many :products, dependent: :restrict_with_error
   has_many :sub_categories_products, through: :sub_categories, source: :products, dependent: :restrict_with_error
 
   validates :name, presence: true
-  validates :name, uniqueness: { scope: :parent_category_id }, allow_blank: true
-  validate :no_child_of_subcategories
+  validates :name, uniqueness: { case_sensitive: false, scope: :parent_id }, allow_blank: true
+  validates_with OneLevelNestingValidator, if: :parent_id?
 
-  after_update_commit :set_products_count, if: :has_parent_category_id_changed?
+  after_update_commit :set_products_count, if: :has_parent_id_changed?
+
+  scope :root, -> { where(parent_id: nil) }
+
+  def update_products_count
+    parent&.update_columns(products_count: (products.size + sub_categories_products.size))
+    update_columns(products_count: (products.size + sub_categories_products.size))
+  end
 
   private
 
   def set_products_count
-    Category.find(parent_category_id_before_last_save).decrement!(:products_count, products_count)
-    parent_category&.increment!(:products_count, products_count)
+    Category.find_by(id: parent_id_before_last_save)&.update_products_count
+    Category.find_by(id: parent_id)&.update_products_count
   end
 
-  def has_parent_category_id_changed?
-    parent_category_id_before_last_save != parent_category_id
-  end
-
-  def has_grandparent?
-    parent_category&.parent_category_id? && parent_category_id?
-  end
-
-  def has_grandchild?
-    Category.exists?(parent_category_id: sub_category_ids)
-  end
-
-  def has_parent_and_child?
-    parent_category_id? && sub_categories.present?
-  end
-
-  def no_child_of_subcategories
-    if has_grandparent? || has_grandchild? || has_parent_and_child?
-      errors.add :base, :nesting_level_too_deep, message: 'only one level of nesting is allowed'
-    end
+  def has_parent_id_changed?
+    parent_id_before_last_save != parent_id
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,7 +13,7 @@ class Category < ApplicationRecord
   scope :root, -> { where(parent_id: nil) }
 
   def update_products_count
-    parent&.update_columns(products_count: (products.size + sub_categories_products.size))
+    parent&.update_columns(products_count: (parent.products.size + parent.sub_categories_products.size))
     update_columns(products_count: (products.size + sub_categories_products.size))
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -14,7 +14,7 @@ class Category < ApplicationRecord
 
   def set_products_count
     Category.find(parent_category_id_before_last_save).decrement!(:products_count, products_count)
-    super_category&.increment!(:products_count, products_count)
+    parent_category&.increment!(:products_count, products_count)
   end
 
   def has_parent_category_id_changed?

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,41 @@
+class Category < ApplicationRecord
+  has_many :sub_categories, class_name: 'Category', foreign_key: 'parent_category_id', dependent: :destroy
+  belongs_to :parent_category, class_name: 'Category', optional: :true
+  has_many :products, dependent: :restrict_with_error
+  has_many :sub_categories_products, through: :sub_categories, source: :products, dependent: :restrict_with_error
+
+  validates :name, presence: true
+  validates :name, uniqueness: { scope: :parent_category_id }, allow_blank: true
+  validate :no_child_of_subcategories
+
+  after_update_commit :set_products_count, if: :has_parent_category_id_changed?
+
+  private
+
+  def set_products_count
+    Category.find(parent_category_id_before_last_save).decrement!(:products_count, products_count)
+    super_category&.increment!(:products_count, products_count)
+  end
+
+  def has_parent_category_id_changed?
+    parent_category_id_before_last_save != parent_category_id
+  end
+
+  def has_grandparent?
+    parent_category&.parent_category_id? && parent_category_id?
+  end
+
+  def has_grandchild?
+    Category.exists?(parent_category_id: sub_category_ids)
+  end
+
+  def has_parent_and_child?
+    parent_category_id? && sub_categories.present?
+  end
+
+  def no_child_of_subcategories
+    if has_grandparent? || has_grandchild? || has_parent_and_child?
+      errors.add :base, :nesting_level_too_deep, message: 'only one level of nesting is allowed'
+    end
+  end
+end

--- a/app/models/concerns/one_level_nesting_validator.rb
+++ b/app/models/concerns/one_level_nesting_validator.rb
@@ -1,0 +1,5 @@
+class OneLevelNestingValidator < ActiveModel::Validator
+  def validate(record)
+    record.errors.add :base, "can have only one level of nesting" if record.parent.parent_id?
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,7 +2,7 @@ class Product < ApplicationRecord
   has_many :line_items, dependent: :restrict_with_error
   has_many :orders, through: :line_items
   has_many :carts, through: :line_items
-  belongs_to :category, counter_cache: true
+  belongs_to :category
 
   validates :title, :description, :image_url, :price, :discount_price, presence: true
   validates :title, uniqueness: true
@@ -26,13 +26,13 @@ class Product < ApplicationRecord
 
   def set_count_on_save
     unless category_id_before_last_save.nil?
-      Category.find(category_id_before_last_save).parent_category&.decrement!(:products_count)
+      Category.find(category_id_before_last_save).update_products_count
     end
-    category.parent_category&.increment!(:products_count)
+    category.update_products_count
   end
 
   def set_count_on_destroy
-    category.parent_category&.decrement!(:products_count)
+    category.update_products_count
   end
 
   def set_discount_price

--- a/app/views/category/index.html.erb
+++ b/app/views/category/index.html.erb
@@ -1,0 +1,11 @@
+<% @categories.each do |category| %>
+  <ul>
+    <h2>Category: <%= category.name %></h2>
+    <% if category.sub_categories.present? %>
+      <h3>Sub Categories of <%= category.name %></h3>
+      <% category.sub_categories.each do |sub_category| %>
+        <li><%= sub_category.name %></li>
+      <% end %>
+    <% end %>
+  </ul>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   get 'sessions/create'
   get 'sessions/destroy'
 
+  resources :category
+
   resources :users do
     # revisit once during routing
     # resources :users do

--- a/db/migrate/20230503070339_create_categories.rb
+++ b/db/migrate/20230503070339_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :categories do |t|
+      t.string :name
+      t.belongs_to :parent_category, foreign_key: { to_table: :categories }
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230503070339_create_categories.rb
+++ b/db/migrate/20230503070339_create_categories.rb
@@ -2,7 +2,7 @@ class CreateCategories < ActiveRecord::Migration[7.0]
   def change
     create_table :categories do |t|
       t.string :name
-      t.belongs_to :parent_category, foreign_key: { to_table: :categories }
+      t.belongs_to :parent, foreign_key: { to_table: :categories }
       t.timestamps
     end
   end

--- a/db/migrate/20230503131235_add_category_id_to_products.rb
+++ b/db/migrate/20230503131235_add_category_id_to_products.rb
@@ -1,0 +1,5 @@
+class AddCategoryIdToProducts < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :products, :category, foreign_key: true
+  end
+end

--- a/db/migrate/20230503135710_add_products_count_to_categories.rb
+++ b/db/migrate/20230503135710_add_products_count_to_categories.rb
@@ -1,0 +1,5 @@
+class AddProductsCountToCategories < ActiveRecord::Migration[7.0]
+  def change
+    add_column :categories, :products_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_27_084419) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_03_135710) do
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
     t.integer "status", default: 0, null: false
     t.string "message_id", null: false
@@ -65,6 +65,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_084419) do
     t.integer "height", default: 0, null: false
   end
 
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.integer "parent_category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "products_count", default: 0, null: false
+    t.index ["parent_category_id"], name: "index_categories_on_parent_category_id"
+  end
+
   create_table "line_items", force: :cascade do |t|
     t.integer "product_id", null: false
     t.integer "cart_id"
@@ -98,6 +107,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_084419) do
     t.boolean "enabled", default: false
     t.decimal "discount_price"
     t.string "permalink"
+    t.integer "category_id"
+    t.index ["category_id"], name: "index_products_on_category_id"
   end
 
   create_table "support_requests", force: :cascade do |t|
@@ -120,9 +131,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_27_084419) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "categories", "categories", column: "parent_category_id"
   add_foreign_key "line_items", "carts"
   add_foreign_key "line_items", "orders"
   add_foreign_key "line_items", "products"
   add_foreign_key "orders", "users"
+  add_foreign_key "products", "categories"
   add_foreign_key "support_requests", "orders"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,11 +67,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_03_135710) do
 
   create_table "categories", force: :cascade do |t|
     t.string "name"
-    t.integer "parent_category_id"
+    t.integer "parent_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "products_count", default: 0, null: false
-    t.index ["parent_category_id"], name: "index_categories_on_parent_category_id"
+    t.index ["parent_id"], name: "index_categories_on_parent_id"
   end
 
   create_table "line_items", force: :cascade do |t|
@@ -131,7 +131,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_03_135710) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "categories", "categories", column: "parent_category_id"
+  add_foreign_key "categories", "categories", column: "parent_id"
   add_foreign_key "line_items", "carts"
   add_foreign_key "line_items", "orders"
   add_foreign_key "line_items", "products"

--- a/test/controllers/category_controller_test.rb
+++ b/test/controllers/category_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Category and Subcategory implementation

There are many categories, and each category can have many sub_categories.

Each product belongs to some category(can either belongs to category or sub_category)

Create db schema and corresponding migrations to implement this in depot app.

Validations

Category’s name should be mandatory
All root category names should be unique
For each category, name of its sub_categories should be unique
Uniqueness validations should only run if name is present
sub category cannot have any child category. means it is only one level of nesting.
Create associations in the Category model for the following

getting all the sub_categories of the category
getting all the products which belong to category
getting all the products which belong to subcategories of a given category
each category should have a count column which should have count of total products under it. So parent category should have the count of its products + products belongs to its sub-category.
Ensure following things

Should not be able to destroy category if any products are associated with it
Should not be able to destroy category if any products are associated with its sub_categories.
Destroying a category should destroy all its sub_categories if no products associated with either of them
Please note that exception should not be raised when calling category.destroy, it should return false in all test cases in which category could not be destroyed.
On some page display all categories with its sub categories in minimal queries