### PR TITLE
Views Extensions

### DIFF
--- a/app/assets/stylesheets/myorders.scss
+++ b/app/assets/stylesheets/myorders.scss
@@ -1,0 +1,18 @@
+*{
+  margin: 0px
+}
+table {
+  display: grid;
+  tr {
+    td.left {
+      background-color: cadetblue;
+      padding: 50px;
+      grid-column: 1/3;
+    }
+
+    td.right {
+      padding: 50px;
+      grid-column: 2/3;
+    }
+  }
+}

--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -40,7 +40,7 @@
     display: none;
 
     // Assume anything bigger than 30em
-    // is a non-mobile device and can 
+    // is a non-mobile device and can
     // fit the image.
     @media (min-width: 30em) {
       display: block;
@@ -72,3 +72,42 @@
     }
   }
 }
+.slider {
+  width: 100%;
+  height: 240px;
+  position: relative;
+}
+.slider img {
+  width: 70%;
+  height: 220px;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+.slider img:first-child{
+  z-index: 1;
+}
+.slider img:nth-child(2){
+  z-index: 0;
+}
+.navigation-button {
+  margin-left: 25%;
+  // text-align: center;
+  position: relative;
+}
+
+.dot {
+  cursor: pointer;
+  height: 15px;
+  width: 15px;
+  margin: 0 2px;
+  background-color: #bbb;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.active,
+.dot:hover {
+  background-color: #717171;
+}
+

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,11 +1,3 @@
-#---
-# Excerpted from "Agile Web Development with Rails 6",
-# published by The Pragmatic Bookshelf.
-# Copyrights apply to this code. It may not be used to create training material,
-# courses, books, articles, and the like. Contact us if you are in doubt.
-# We make no guarantees that this code is fit for any purpose.
-# Visit http://www.pragmaticprogrammer.com/titles/rails6 for more book information.
-#---
 class ProductsController < ApplicationController
   before_action :set_product, only: [:show, :edit, :update, :destroy]
 
@@ -13,6 +5,10 @@ class ProductsController < ApplicationController
   # GET /products.json
   def index
     @products = Product.all.order(:title)
+    respond_to do |format|
+      format.html { render :index }
+      format.json { render json: @products.joins(:category).select(:title, 'name as category_name') }
+    end
   end
 
   # GET /products/1
@@ -59,7 +55,7 @@ class ProductsController < ApplicationController
 
         @products = Product.all.order(:title)
         ActionCable.server.broadcast 'products',
-          html: render_to_string('store/index', layout: false)
+          { html: render_to_string('store/index', layout: false) }
       else
         format.html { render :edit }
         format.json { render json: @product.errors,
@@ -97,6 +93,6 @@ class ProductsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def product_params
-      params.require(:product).permit(:title, :description, :image_url, :price)
+      params.require(:product).permit(:title, :description, :image_url, :price, :category_id, images: [])
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
+  layout "myorders", only: [:orders, :line_items]
   # GET /users
   # GET /users.json
   def index
@@ -72,12 +73,10 @@ class UsersController < ApplicationController
 
   def orders
     @orders = current_user.orders.paginate(page: params[:page], per_page: 5)
-    render layout: "myorders"
   end
 
   def line_items
     @line_items = current_user.line_items.paginate(page: params[:page], per_page: 5)
-    render layout: "myorders"
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,7 @@ class UsersController < ApplicationController
   # GET /users/new
   def new
     @user = User.new
+    @user.build_address
   end
 
   # GET /users/1/edit
@@ -71,10 +72,12 @@ class UsersController < ApplicationController
 
   def orders
     @orders = current_user.orders.paginate(page: params[:page], per_page: 5)
+    render layout: "myorders"
   end
 
   def line_items
     @line_items = current_user.line_items.paginate(page: params[:page], per_page: 5)
+    render layout: "myorders"
   end
 
   private
@@ -86,6 +89,6 @@ class UsersController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, address_attributes: [:state, :country, :city, :pincode])
   end
 end

--- a/app/javascript/packs/slider.js
+++ b/app/javascript/packs/slider.js
@@ -1,0 +1,24 @@
+var imgs = document.getElementsByClassName('slider-img');
+var dots = document.getElementsByClassName('dot');
+var currentImg = 0; // index of the first image
+const interval = 3000; // duration of the slide
+
+function changeSlide(n) {
+  for (var i = 0; i < imgs.length; i++) { // reset
+    imgs[i].style.opacity = 0;
+    dots[i].className = dots[i].className.replace(' active', '');
+  }
+
+  currentImg = (currentImg + 1) % imgs.length; // update the index number
+
+  if (n != undefined) {
+      clearInterval(timer);
+      timer = setInterval(changeSlide, interval);
+      currentImg = n;
+  }
+
+  imgs[currentImg].style.opacity = 1;
+  dots[currentImg].className += ' active';
+}
+
+var timer = setInterval(changeSlide, interval);

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,3 @@
+class Address < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,5 @@
 class Address < ApplicationRecord
   belongs_to :user
+  validates :state, :city, :country, :pincode, presence: true
+  validates_length_of :pincode, is: 6, allow_blank: true
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,6 +2,7 @@ class Product < ApplicationRecord
   has_many :line_items, dependent: :restrict_with_error
   has_many :orders, through: :line_items
   has_many :carts, through: :line_items
+  has_many_attached :images, dependent: :destroy
   belongs_to :category
 
   validates :title, :description, :image_url, :price, :discount_price, presence: true
@@ -12,6 +13,7 @@ class Product < ApplicationRecord
   validates :permalink, uniqueness: true, format: { with: ::PERMALINK_REGEX }
   validates :description, format: { with: ::DESCRIPTION_REGEX }
   validates :discount_price, numericality: { less_than_or_equal_to: :price }, allow_blank: true, if: :price?
+  validates_length_of :images, in: 1..3, too_short: 'must have atleast one image', too_long: 'cannot have more than 3 images'
 
   after_initialize :set_title, unless: :title?
   before_validation :set_discount_price, unless: :discount_price?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   has_many :orders, dependent: :restrict_with_error
   has_many :line_items, through: :orders
   has_one :address, dependent: :destroy
-  accepts_nested_attributes_for :address
+  accepts_nested_attributes_for :address, allow_destroy: true, update_only: true
 
   validates :name, presence: true, uniqueness: true
   has_secure_password

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_many :orders, dependent: :restrict_with_error
   has_many :line_items, through: :orders
+  has_one :address, dependent: :destroy
+  accepts_nested_attributes_for :address
 
   validates :name, presence: true, uniqueness: true
   has_secure_password

--- a/app/views/layouts/myorders.html.erb
+++ b/app/views/layouts/myorders.html.erb
@@ -1,0 +1,27 @@
+<! DOCTYPE html>
+<html>
+  <head>
+    <title>Pragprog Books Online Store</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "myorders", media: 'all', "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+  <body>
+    <table>
+      <tr>
+        <td class="left">
+          <nav class="side_nav">
+            <ul>
+              <li><%= button_to 'Logout', logout_path, method: :delete %></li>
+            </ul>
+          </nav>
+        </td>
+        <td class="right">
+          <%= yield %>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: product, local: true) do |form| %>
+<%= form_with(model: product, local: true, multipart: true) do |form| %>
   <% if product.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(product.errors.count, "error") %>
@@ -22,10 +22,9 @@
     <%= form.text_area :description, rows: 10, cols: 60 %>
   </div>
 
-  <div class="field">
-    <%= form.label :image_url %>
-    <%= form.text_field :image_url %>
-  </div>
+
+  <%= form.label :images, "Upload images", style: "display: block" %>
+  <%= form.file_field :images, multiple: true %>
 
   <div class="field">
     <%= form.label :price %>
@@ -45,6 +44,11 @@
   <div class="field">
     <%= form.label :permalink %>
     <%= form.text_field :permalink %>
+  </div>
+
+  <div class="field">
+    <%= form.label :category_id, style: "display: block" %>
+    <%= form.collection_select :category_id, Category.order(:name), :id, :name, { include_blank: 'Select one' } %>
   </div>
 
   <div class="actions">

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -24,7 +24,7 @@
 
 
   <%= form.label :images, "Upload images", style: "display: block" %>
-  <%= form.file_field :images, multiple: true %>
+  <%= form.file_field :images, accept: 'image/jpg,image/jpeg', multiple: true %>
 
   <div class="field">
     <%= form.label :price %>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,8 +1,8 @@
 <div id="<%= dom_id product %>">
 
 <div class="slider">
-<% product.images.to_a.each do |img| %>
-  <%= image_tag(img, class: 'slider-img') if img.present? %>
+<% product.images.each do |img| %>
+  <%= image_tag(img, class: 'slider-img') %>
   <% end %>
 </div>
 <div class="navigation-button">

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,9 +1,9 @@
 <div id="<%= dom_id product %>">
 
 <div class="slider">
-  <%= image_tag(product.images.to_a.first, class: 'slider-img') if product.images.to_a.first %>
-  <%= image_tag(product.images.to_a.second, class: 'slider-img') if product.images.to_a.second %>
-  <%= image_tag(product.images.to_a.third, class: 'slider-img') if product.images.to_a.third %>
+<% product.images.to_a.each do |img| %>
+  <%= image_tag(img, class: 'slider-img') if img.present? %>
+  <% end %>
 </div>
 <div class="navigation-button">
   <span class="dot active"></span>
@@ -33,12 +33,9 @@
 
   <td class="actions">
           <ul>
-            <li><%= link_to 'Show', product %></li>
             <li><%= link_to 'Edit', edit_product_path(product) %></li>
             <li>
-              <%= link_to 'Destroy',  product,
-                          method: :delete,
-                          data: { confirm: 'Are you sure?' } %>
+              <%= link_to 'Destroy',  product, method: :delete, data: { confirm: 'Are you sure?' } %>
             </li>
           </ul>
         </td>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,4 +1,16 @@
 <div id="<%= dom_id product %>">
+
+<div class="slider">
+  <%= image_tag(product.images.to_a.first, class: 'slider-img') if product.images.to_a.first %>
+  <%= image_tag(product.images.to_a.second, class: 'slider-img') if product.images.to_a.second %>
+  <%= image_tag(product.images.to_a.third, class: 'slider-img') if product.images.to_a.third %>
+</div>
+<div class="navigation-button">
+  <span class="dot active"></span>
+  <span class="dot"></span>
+  <span class="dot"></span>
+</div>
+
   <p>
     <strong>Title:</strong>
     <%= product.title %>
@@ -19,4 +31,16 @@
     <%= product.price %>
   </p>
 
+  <td class="actions">
+          <ul>
+            <li><%= link_to 'Show', product %></li>
+            <li><%= link_to 'Edit', edit_product_path(product) %></li>
+            <li>
+              <%= link_to 'Destroy',  product,
+                          method: :delete,
+                          data: { confirm: 'Are you sure?' } %>
+            </li>
+          </ul>
+        </td>
 </div>
+<br

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,9 +1,14 @@
+<%= javascript_pack_tag 'slider' %>
 <% if notice %>
   <aside id="notice"><%= notice %></aside>
 <% end %>
 
 <h1>Products</h1>
-
+<tbody>
+<% @products.each do |product| %>
+  <%= render product %>
+<% end %>
+</tbody>
 <table>
   <tfoot>
     <tr>
@@ -12,33 +17,5 @@
       </td>
     </tr>
   </tfoot>
-  <tbody>
-    <% @products.each do |product| %>
-      <tr class="<%= cycle('list_line_odd', 'list_line_even') %>">
 
-        <td class="image">
-          <%= image_tag(product.image_url, class: 'list_image') %>
-        </td>
-
-        <td class="description">
-          <h1><%= product.title %></h1>
-          <p>
-            <%= truncate(strip_tags(product.description), length: 80) %>
-          </p>
-        </td>
-
-        <td class="actions">
-          <ul>
-            <li><%= link_to 'Show', product %></li>
-            <li><%= link_to 'Edit', edit_product_path(product) %></li>
-            <li>
-              <%= link_to 'Destroy',  product, 
-                          method: :delete,
-                          data: { confirm: 'Are you sure?' } %>
-            </li>
-          </ul>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
 </table>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -4,12 +4,37 @@
 <% end %>
 
 <h1>Products</h1>
-<tbody>
-<% @products.each do |product| %>
-  <%= render product %>
-<% end %>
-</tbody>
+
 <table>
+  <tbody>
+    <% @products.each do |product| %>
+      <tr class="<%= cycle('list_line_odd', 'list_line_even') %>">
+
+        <td class="image">
+          <%= image_tag(product.image_url, class: 'list_image') %>
+        </td>
+
+        <td class="description">
+          <h1><%= product.title %></h1>
+          <p>
+            <%= truncate(strip_tags(product.description), length: 80) %>
+          </p>
+        </td>
+
+        <td class="actions">
+          <ul>
+            <li><%= link_to 'Show', product %></li>
+            <li><%= link_to 'Edit', edit_product_path(product) %></li>
+            <li>
+              <%= link_to 'Destroy',  product,
+                          method: :delete,
+                          data: { confirm: 'Are you sure?' } %>
+            </li>
+          </ul>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
   <tfoot>
     <tr>
       <td colspan="3">
@@ -17,5 +42,4 @@
       </td>
     </tr>
   </tfoot>
-
 </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,8 +4,5 @@
 <%= render @product %>
 
 <div>
-  <%= link_to "Edit this product", edit_product_path(@product) %> |
   <%= link_to "Back to products", products_path %>
-
-  <%= button_to "Destroy this product", @product, method: :delete %>
 </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_pack_tag 'slider' %>
 <p style="color: green"><%= notice %></p>
 
 <%= render @product %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -50,7 +50,7 @@
         <%= addresses_form.label :country %>
         <%= addresses_form.text_field :country %>
         <%= addresses_form.label :pincode %>
-        <%= addresses_form.number_field :pincode, in: 100000..999999 %>
+        <%= addresses_form.number_field :pincode %>
     <% end %>
   </ul>
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -40,6 +40,20 @@
 
   </div>
 
+  Addresses:
+  <ul>
+    <%= form.fields_for :address do |addresses_form| %>
+        <%= addresses_form.label :state %>
+        <%= addresses_form.text_field :state %>
+        <%= addresses_form.label :city %>
+        <%= addresses_form.text_field :city %>
+        <%= addresses_form.label :country %>
+        <%= addresses_form.text_field :country %>
+        <%= addresses_form.label :pincode %>
+        <%= addresses_form.number_field :pincode, in: 100000..999999 %>
+    <% end %>
+  </ul>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,7 +1,19 @@
 <div id="<%= dom_id user %>">
   <p>
     <strong>Name:</strong>
-    <%= user.name %>
+    <%= user.name %><br>
+    <strong>Email:</strong>
+    <%= user.email %><br>
+    <strong>Address:</strong><br>
+    <strong>State:</strong>
+    <%= user.address&.state %><br>
+    <strong>Country:</strong>
+    <%= user.address&.country %><br>
+    <strong>City:</strong>
+    <%= user.address&.city %><br>
+    <strong>Pincode:</strong>
+    <%= user.address&.state %><br>
+    <br>
   </p>
 
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -8,6 +8,7 @@
     <p>
       <%= link_to "Show this user", user %>
     </p>
+    <br>
   <% end %>
 </div>
 

--- a/db/migrate/20230511095558_create_addresses.rb
+++ b/db/migrate/20230511095558_create_addresses.rb
@@ -5,7 +5,7 @@ class CreateAddresses < ActiveRecord::Migration[7.0]
       t.string :city
       t.string :country
       t.integer :pincode
-      t.references :user, foreign_key: true
+      t.references :user, foreign_key: true, null: false
 
       t.timestamps
     end

--- a/db/migrate/20230511095558_create_addresses.rb
+++ b/db/migrate/20230511095558_create_addresses.rb
@@ -1,0 +1,13 @@
+class CreateAddresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :addresses do |t|
+      t.string :state
+      t.string :city
+      t.string :country
+      t.integer :pincode
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_03_135710) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_11_095558) do
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
     t.integer "status", default: 0, null: false
     t.string "message_id", null: false
@@ -56,6 +56,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_03_135710) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "addresses", force: :cascade do |t|
+    t.string "state"
+    t.string "city"
+    t.string "country"
+    t.integer "pincode"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 
   create_table "carts", force: :cascade do |t|
@@ -131,6 +142,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_03_135710) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "users"
   add_foreign_key "categories", "categories", column: "parent_id"
   add_foreign_key "line_items", "carts"
   add_foreign_key "line_items", "orders"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,7 +63,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_095558) do
     t.string "city"
     t.string "country"
     t.integer "pincode"
-    t.integer "user_id"
+    t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_addresses_on_user_id"

--- a/lib/tasks/port_legacy_products.rake
+++ b/lib/tasks/port_legacy_products.rake
@@ -1,0 +1,4 @@
+desc 'Assign first category to all products without Category'
+task :port_legacy_products => :environment do
+  Product.where(category_id: nil).update_all(category_id: Category.first.id)
+end


### PR DESCRIPTION
Create a select box for category in product create & edit form. All categories and sub_categories’ names should be present in the dropdown. Product should not be created/updated without a category. Application should display an error message if somebody is trying to create product without  selecting category. First option in the category dropdown should be "Select One", and this should not be considered as category, basically it is a placeholder. For the products already created, assign the first category to all products from a custom rake task named port_legacy_products.
Create a Address model with attributes - State, City, Country, Pincode
Every user has one address. On user creation and edit form, take input for his address also. So user form would have user's fields and address fields too.

Create a layout with your own name lets say myorders. users/orders and users/line_items should use this layout.

Product's index page should display all products in json format when I add .json in the URL like: /products.json. In JSON, only the name and category name should be included, no other field

Make use of partial in product listing
Add functionality to upload product image. Don't use any gem, refer rails guides.
Now modify upload product image so that it can have max 3 images, then on the product listing page, display the first image, and on the product show page display all images in a js slider.
