### PR TITLE
Routing Extensions

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,9 +1,11 @@
 class Admin::CategoriesController < ApplicationController
+  before_action :is_admin?
+
   def index
-    if current_user.admin?
-      @categories = Category.all
-    else
-      redirect_to store_index_path, notice: "You don't have privilege to access this section"
-    end
+    @categories = Category.all
+  end
+
+  def products
+    @category_products = Category.find(params[:id]).products +  Category.find(params[:id]).sub_categories_products
   end
 end

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,0 +1,9 @@
+class Admin::CategoriesController < ApplicationController
+  def index
+    if current_user.admin?
+      @categories = Category.all
+    else
+      redirect_to store_index_path, notice: "You don't have privilege to access this section"
+    end
+  end
+end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -1,0 +1,10 @@
+class Admin::ReportsController < ApplicationController
+  def index
+    if current_user.admin?
+      params[:from] ||= 5.days.ago
+      @order = Order.by_date(params[:from], params[:to])
+    else
+      redirect_to store_index_path, notice: "You don't have privilege to access this section"
+    end
+  end
+end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -1,10 +1,8 @@
 class Admin::ReportsController < ApplicationController
+  before_action :is_admin?
+
   def index
-    if current_user.admin?
-      params[:from] ||= 5.days.ago
-      @order = Order.by_date(params[:from], params[:to])
-    else
-      redirect_to store_index_path, notice: "You don't have privilege to access this section"
-    end
+    params[:from] ||= 5.days.ago
+    @order = Order.by_date(params[:from], params[:to])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,6 +52,10 @@ class ApplicationController < ActionController::Base
       end
     end
 
+    def is_admin?
+      redirect_to store_index_path, notice: "You don't have privilege to access this section" unless current_user.admin?
+    end
+
     def set_i18n_locale_from_params
       if params[:locale]
         if I18n.available_locales.map(&:to_s).include?(params[:locale])

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -1,4 +1,5 @@
 class CategoryController < ApplicationController
   def index
     @categories = Category.root.includes(:sub_categories)
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,8 @@ class SessionsController < ApplicationController
     user = User.find_by(name: params[:name])
     if user.try(:authenticate, params[:password])
       session[:user_id] = user.id
-      redirect_to admin_url
+      current_user.admin? ? (redirect_to admin_reports_url) : (redirect_to store_index_url)
+      session[:last_active] = Time.current
     else
       redirect_to login_url, alert: "Invalid user/password combination"
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,10 @@ class User < ApplicationRecord
   class Error < StandardError
   end
 
+  def admin?
+    role == 'admin'
+  end
+
   private
 
   def send_welcome_email

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -1,0 +1,14 @@
+<table>
+  <tr>
+      <th>Category name</th>
+      <th>Parent category</th>
+      <th>Number of products</th>
+  </tr>
+  <% @categories.each do |category| %>
+    <tr>
+      <td><%= category.name %></td>
+      <td><%= category.parent.try(:name) || '-' %></td>
+      <td><%= category.products_count %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <% @categories.each do |category| %>
     <tr>
-      <td><%= category.name %></td>
+      <td><%= link_to category.name, products_admin_category_path(category.id) %></td>
       <td><%= category.parent.try(:name) || '-' %></td>
       <td><%= category.products_count %></td>
     </tr>

--- a/app/views/admin/categories/products.html.erb
+++ b/app/views/admin/categories/products.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "products/product", collection: @category_products %>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -1,0 +1,14 @@
+<h3>Select Date range</h3>
+<%= form_with url: '/admin/reports', method: :get do |form| %>
+  From:
+  <%= form.date_field :from %>
+  <br>
+  To:
+  <%= form.date_field :to %>
+  <br>
+  <%= form.submit %>
+<% end %>
+<% @order.each_with_index do |order, index| %>
+  <h2>Order#<%= index + 1 %></h2>
+  <%= render partial: 'orders/order', object: order %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
 
     <%= stylesheet_link_tag 'application', media: 'all',
                             'data-turbolinks-track': 'reload' %>
-    
+
     <%= javascript_pack_tag %>
     <script type="text/javascript">
       I18n.defaultLocale = "<%= I18n.default_locale %>";
@@ -21,7 +21,7 @@
     <header class="main">
       <aside>
         <%= form_tag store_index_path, class: 'locale' do %>
-          <%= select_tag 'set_locale', 
+          <%= select_tag 'set_locale',
             options_for_select(LANGUAGES, I18n.locale.to_s),
             onchange: 'this.form.submit()' %>
           <%= submit_tag 'submit', id: "submit_locale_change" %>
@@ -60,5 +60,9 @@
         <%= yield %>
       </main>
     </section>
+    <footer>
+      <div>Total Hit Count: <%= @hit_count %></div>
+      <div>Your Ip Address: <%= @client_ip %></div>
+    </footer>
   </body>
 </html>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_pack_tag 'slider' %>
+
 <div id="<%= dom_id product %>">
 
 <div class="slider">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,3 +1,7 @@
+<% if notice %>
+  <aside id="notice"><%= notice %></aside>
+<% end %>
+
 <section class="depot_form">
   <% if flash[:alert] %>
     <aside class="notice"><%= flash[:alert] %></aside>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -2,3 +2,4 @@ PERMALINK_REGEX = /\A([\w]+-){2,}[\w]+\z/
 DESCRIPTION_REGEX = /\A(\w+ ){4,9}\w+ *\z/
 URL_REGEX = /\w+\.(gif|jpg|png)\z/i
 ADMIN_EMAIL = "admin@depot.com"
+FIREFOX_BROWSER_REGEX = /firefox/i.freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,41 +1,50 @@
 Rails.application.routes.draw do
-  controller :sessions do
-    get  'login' => :new
-    post 'login' => :create
-    delete 'logout' => :destroy
-  end
+  constraints(-> (request) { request.headers['User-Agent'] !~ FIREFOX_BROWSER_REGEX}) do
+    controller :sessions do
+      get  'login' => :new
+      post 'login' => :create
+      delete 'logout' => :destroy
+    end
 
-  get 'sessions/create'
-  get 'sessions/destroy'
+    get 'sessions/create'
+    get 'sessions/destroy'
 
-  resources :category
+    resources :category
 
-  resources :users do
-    # revisit once during routing
-    # resources :users do
-    #   get 'orders', to: 'users#orders'
-    # end
-    collection do
-      get 'orders', to: 'users#orders'
-      get 'line_items', to: 'users#line_items'
+    get '/my-orders', to: 'users#orders'
+    get '/my-items', to: 'users#line_items'
+
+    resources :users do
+      # revisit once during routing
+      # resources :users do
+      #   get 'orders', to: 'users#orders'
+      # end
+      collection do
+        get 'orders', to: 'users#orders'
+        get 'line_items', to: 'users#line_items'
+      end
+    end
+
+    resources :products do
+      get :who_bought, on: :member
+    end
+
+    resources :support_requests, only: [ :index, :update ]
+
+    namespace :admin do
+      get 'reports', to: 'reports#index'
+      resources :categories do
+        get 'products', on: :member
+      end
+
+    end
+
+    scope '(:locale)' do
+      resources :orders
+      resources :line_items
+      resources :carts
+      root 'store#index', as: 'store_index', via: :all
     end
   end
-
-  resources :products do
-    get :who_bought, on: :member
-  end
-
-  resources :support_requests, only: [ :index, :update ]
-
-  namespace :admin do
-    get 'reports', to: 'reports#index'
-    get 'categories', to: 'categories#index'
-  end
-
-  scope '(:locale)' do
-    resources :orders
-    resources :line_items
-    resources :carts
-    root 'store#index', as: 'store_index', via: :all
-  end
+  root "store#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'admin' => 'admin#index'
   controller :sessions do
     get  'login' => :new
     post 'login' => :create
@@ -27,6 +26,11 @@ Rails.application.routes.draw do
   end
 
   resources :support_requests, only: [ :index, :update ]
+
+  namespace :admin do
+    get 'reports', to: 'reports#index'
+    get 'categories', to: 'categories#index'
+  end
 
   scope '(:locale)' do
     resources :orders

--- a/db/migrate/20230517144824_add_role_column_to_users.rb
+++ b/db/migrate/20230517144824_add_role_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleColumnToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :string, default: 'user'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_11_095558) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_17_144824) do
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
     t.integer "status", default: 0, null: false
     t.string "message_id", null: false
@@ -138,6 +138,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_095558) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "email"
+    t.string "role", default: "user"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/lib/tasks/update_legacy_users_role.rake
+++ b/lib/tasks/update_legacy_users_role.rake
@@ -1,0 +1,4 @@
+desc 'Assigns role as admin for email provided'
+task :make_admin, [:email] => :environment do |t, args|
+  User.where(email: args[:email]).update_all(role: 'admin')
+end


### PR DESCRIPTION
Make a route /my-orders for /users/orders & /my-items for /users/items 
These routes should be accessed on GET only
Throughout the application routes for the products controller should be Books. l
eg: /books, /books/2/edit
Clicking on the category name in /admin/categories page. should display all the products belongs to that category or any of its sub-category. URL should be /categories/5/books. 
Note that the id in the url should be an integer, if not then redirect to home page. This redirection should be done using routing only
Add a constraint that only home page can be accessed from Firefox. No other page can be seen on firefox. If somebody tries access any other page from Firefox then default rails  “no route found” should come
