### PR TITLE
Routing Extensions

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -4,7 +4,11 @@ class ProductsController < ApplicationController
   # GET /products
   # GET /products.json
   def index
-    @products = Product.all.order(:title)
+    if params[:category_id]
+      @products = Category.find(params[:category_id]).products +  Category.find(params[:category_id]).sub_categories_products
+    else
+      @products = Product.all.order(:title)
+    end
     respond_to do |format|
       format.html { render :index }
       format.json { render json: @products.joins(:category).select(:title, 'name as category_name') }

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <% @categories.each do |category| %>
     <tr>
-    <td><%= link_to category.name, category_books_path(category.id) %></td>
+    <td><%= link_to category.name, category_products_path(category.id) %></td>
       <td><%= category.parent.try(:name) || '-' %></td>
       <td><%= category.products_count %></td>
     </tr>

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -6,7 +6,7 @@
   </tr>
   <% @categories.each do |category| %>
     <tr>
-      <td><%= category.name %></td>
+    <td><%= link_to category.name, category_books_path(category.id) %></td>
       <td><%= category.parent.try(:name) || '-' %></td>
       <td><%= category.products_count %></td>
     </tr>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_pack_tag 'slider' %>
+
 <div id="<%= dom_id product %>">
 
 <div class="slider">

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -3,3 +3,6 @@ DESCRIPTION_REGEX = /\A(\w+ ){4,9}\w+ *\z/
 URL_REGEX = /\w+\.(gif|jpg|png)\z/i
 ADMIN_EMAIL = "admin@depot.com"
 PAGE_PATH_REGEX = /\/(.*)(\?)?/
+FIREFOX_BROWSER_REGEX = /firefox/i.freeze
+DIGIT_REGEX = /[\d]+/.freeze
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  root 'store#index', as: 'store_index', via: :all
   constraints(-> (request) { request.headers['User-Agent'] !~ FIREFOX_BROWSER_REGEX}) do
     controller :sessions do
       get  'login' => :new
@@ -9,9 +10,6 @@ Rails.application.routes.draw do
     get 'sessions/create'
     get 'sessions/destroy'
 
-    get '/my-orders', to: 'users#orders'
-    get '/my-items', to: 'users#line_items'
-
     resources :users
 
     resources :products, path: '/books' do
@@ -21,21 +19,21 @@ Rails.application.routes.draw do
     resources :support_requests, only: [ :index, :update ]
 
     resources :category do
-      resources :products, path: '/books', as: 'books', constraints: { category_id: DIGIT_REGEX }
-      resources :products, path: '/books', as: 'books', to: redirect('/')
+      resources :products, path: '/books', constraints: { category_id: DIGIT_REGEX }
+      resources :products, path: '/books', to: redirect('/')
     end
 
     namespace :admin do
-      get 'reports', to: 'reports#index'
-      get 'categories', to: 'categories#index'
+      get :reports, to: 'reports#index'
+      get :categories, to: 'categories#index'
     end
 
     scope '(:locale)' do
       resources :orders
       resources :line_items
       resources :carts
-      root 'store#index', as: 'store_index', via: :all
+      get '/my-orders', to: 'users#orders'
+      get '/my-items', to: 'users#line_items'
     end
   end
-  root "store#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,41 +1,41 @@
 Rails.application.routes.draw do
-  controller :sessions do
-    get  'login' => :new
-    post 'login' => :create
-    delete 'logout' => :destroy
-  end
+  constraints(-> (request) { request.headers['User-Agent'] !~ FIREFOX_BROWSER_REGEX}) do
+    controller :sessions do
+      get  'login' => :new
+      post 'login' => :create
+      delete 'logout' => :destroy
+    end
 
-  get 'sessions/create'
-  get 'sessions/destroy'
+    get 'sessions/create'
+    get 'sessions/destroy'
 
-  resources :category
+    get '/my-orders', to: 'users#orders'
+    get '/my-items', to: 'users#line_items'
 
-  resources :users do
-    # revisit once during routing
-    # resources :users do
-    #   get 'orders', to: 'users#orders'
-    # end
-    collection do
-      get 'orders', to: 'users#orders'
-      get 'line_items', to: 'users#line_items'
+    resources :users
+
+    resources :products, path: '/books' do
+      get :who_bought, on: :member
+    end
+
+    resources :support_requests, only: [ :index, :update ]
+
+    resources :category do
+      resources :products, path: '/books', as: 'books', constraints: { category_id: DIGIT_REGEX }
+      resources :products, path: '/books', as: 'books', to: redirect('/')
+    end
+
+    namespace :admin do
+      get 'reports', to: 'reports#index'
+      get 'categories', to: 'categories#index'
+    end
+
+    scope '(:locale)' do
+      resources :orders
+      resources :line_items
+      resources :carts
+      root 'store#index', as: 'store_index', via: :all
     end
   end
-
-  resources :products do
-    get :who_bought, on: :member
-  end
-
-  resources :support_requests, only: [ :index, :update ]
-
-  namespace :admin do
-    get 'reports', to: 'reports#index'
-    get 'categories', to: 'categories#index'
-  end
-
-  scope '(:locale)' do
-    resources :orders
-    resources :line_items
-    resources :carts
-    root 'store#index', as: 'store_index', via: :all
-  end
+  root "store#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,15 +12,15 @@ Rails.application.routes.draw do
 
     resources :users
 
-    resources :products, path: '/books' do
+    resources :products, path: :books do
       get :who_bought, on: :member
     end
 
     resources :support_requests, only: [ :index, :update ]
 
     resources :category do
-      resources :products, path: '/books', constraints: { category_id: DIGIT_REGEX }
-      resources :products, path: '/books', to: redirect('/')
+      resources :products, path: :books, constraints: { category_id: DIGIT_REGEX }
+      resources :products, path: :books, to: redirect('/')
     end
 
     namespace :admin do
@@ -32,8 +32,8 @@ Rails.application.routes.draw do
       resources :orders
       resources :line_items
       resources :carts
-      get '/my-orders', to: 'users#orders'
-      get '/my-items', to: 'users#line_items'
+      get 'my-orders', to: 'users#orders'
+      get 'my-items', to: 'users#line_items'
     end
   end
 end


### PR DESCRIPTION
Make a route /my-orders for /users/orders & /my-items for /users/items 
These routes should be accessed on GET only
Throughout the application routes for the products controller should be Books. l
eg: /books, /books/2/edit
Clicking on the category name in /admin/categories page. should display all the products belongs to that category or any of its sub-category. URL should be /categories/5/books. 
Note that the id in the url should be an integer, if not then redirect to home page. This redirection should be done using routing only
Add a constraint that only home page can be accessed from Firefox. No other page can be seen on firefox. If somebody tries access any other page from Firefox then default rails  “no route found” should come
